### PR TITLE
Fixes camera Uncaught (in promise)

### DIFF
--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -137,7 +137,7 @@ export class CameraPWA {
   async initPhotoCapabilities(imageCapture: any) {
     const c = await imageCapture.getPhotoCapabilities();
 
-    if (c.fillLightMode.length > 1) {
+    if (c.fillLightMode && c.fillLightMode.length > 1) {
       this.flashModes = c.fillLightMode.map(m => m);
 
       // Try to recall the current flash mode


### PR DESCRIPTION
Uncaught (in promise) TypeError: Cannot read property 'length' of undefined pwa-camera.entry.js?da8b:404